### PR TITLE
Support viewing, listing, and deleting Linode instances

### DIFF
--- a/lib/fog/linode/compute.rb
+++ b/lib/fog/linode/compute.rb
@@ -15,6 +15,9 @@ module Fog
       request :view_stack_script
       request :list_images
       request :view_image
+      request :list_servers
+      request :view_server
+      request :delete_server
 
       model_path 'fog/linode/compute/models'
       collection :types

--- a/lib/fog/linode/compute/requests/delete_server.rb
+++ b/lib/fog/linode/compute/requests/delete_server.rb
@@ -1,0 +1,17 @@
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        def delete_server(id)
+          response = request(
+            expects: [200],
+            method: 'DELETE',
+            path: "linode/instances/#{id}"
+          )
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/requests/list_servers.rb
+++ b/lib/fog/linode/compute/requests/list_servers.rb
@@ -1,0 +1,16 @@
+require 'fog/linode/paginated_collection'
+
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        include PaginatedCollection
+
+        def list_servers(options = {})
+          make_paginated_request('linode/instances', options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/requests/view_server.rb
+++ b/lib/fog/linode/compute/requests/view_server.rb
@@ -1,0 +1,17 @@
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        def view_server(id)
+          response = request(
+            expects: [200],
+            method: 'GET',
+            path: "linode/instances/#{id}"
+          )
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/delete_server.yml
+++ b/spec/cassettes/delete_server.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.linode.com/v4/linode/instances/13985782
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.pre fog-core/1.45.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 13 May 2019 15:41:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1557762197'
+      Retry-After:
+      - '119'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Authorization, X-Filter
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: "{}"
+    http_version: 
+  recorded_at: Mon, 13 May 2019 15:41:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/list_servers.yml
+++ b/spec/cassettes/list_servers.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.linode.com/v4/linode/instances
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.pre fog-core/1.45.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 13 May 2019 15:39:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2435'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store, private, max-age=60, s-maxage=60
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      Vary:
+      - Authorization, X-Filter, Authorization, X-Filter
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1557762086'
+      Retry-After:
+      - '118'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"pages": 1, "data": [{"updated": "2019-05-13T15:32:59", "type": "g6-standard-1",
+        "created": "2019-05-13T15:32:59", "specs": {"memory": 2048, "transfer": 2000,
+        "vcpus": 1, "disk": 51200}, "status": "running", "ipv6": "2600:3c02::f03c:91ff:fec3:ffe4/64",
+        "hypervisor": "kvm", "alerts": {"cpu": 90, "network_in": 10, "network_out":
+        10, "transfer_quota": 80, "io": 10000}, "id": 13985768, "backups": {"schedule":
+        {"day": null, "window": null}, "enabled": false}, "watchdog_enabled": true,
+        "label": "debian-us-southeast", "ipv4": ["45.33.103.126"], "tags": [], "region":
+        "us-southeast", "group": "", "image": "linode/debian9"}, {"updated": "2019-05-13T15:33:28",
+        "type": "g6-standard-1", "created": "2019-05-13T15:33:28", "specs": {"memory":
+        2048, "transfer": 2000, "vcpus": 1, "disk": 51200}, "status": "running", "ipv6":
+        "2600:3c04::f03c:91ff:fec3:ff43/64", "hypervisor": "kvm", "alerts": {"cpu":
+        90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+        "id": 13985775, "backups": {"schedule": {"day": null, "window": null}, "enabled":
+        false}, "watchdog_enabled": true, "label": "alpine-ca-central", "ipv4": ["172.105.6.10"],
+        "tags": [], "region": "ca-central", "group": "", "image": "linode/alpine3.9"},
+        {"updated": "2019-05-13T15:34:03", "type": "g6-standard-1", "created": "2019-05-13T15:34:03",
+        "specs": {"memory": 2048, "transfer": 2000, "vcpus": 1, "disk": 51200}, "status":
+        "running", "ipv6": "2600:3c00::f03c:91ff:fec3:ff5d/64", "hypervisor": "kvm",
+        "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota":
+        80, "io": 10000}, "id": 13985782, "backups": {"schedule": {"day": null, "window":
+        null}, "enabled": false}, "watchdog_enabled": true, "label": "centos-us-central",
+        "ipv4": ["198.58.120.51"], "tags": [], "region": "us-central", "group": "",
+        "image": "linode/centos7"}, {"updated": "2019-05-13T15:34:22", "type": "g6-standard-1",
+        "created": "2019-05-13T15:34:22", "specs": {"memory": 2048, "transfer": 2000,
+        "vcpus": 1, "disk": 51200}, "status": "running", "ipv6": "2600:3c03::f03c:91ff:fec3:ff78/64",
+        "hypervisor": "kvm", "alerts": {"cpu": 90, "network_in": 10, "network_out":
+        10, "transfer_quota": 80, "io": 10000}, "id": 13985783, "backups": {"schedule":
+        {"day": null, "window": null}, "enabled": false}, "watchdog_enabled": true,
+        "label": "arch-us-east", "ipv4": ["172.104.208.137"], "tags": [], "region":
+        "us-east", "group": "", "image": "linode/arch"}], "page": 1, "results": 4}'
+    http_version: 
+  recorded_at: Mon, 13 May 2019 15:39:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/view_server.yml
+++ b/spec/cassettes/view_server.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.linode.com/v4/linode/instances/13985782
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.pre fog-core/1.45.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 13 May 2019 15:39:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '596'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store, private, max-age=60, s-maxage=60
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      Vary:
+      - Authorization, X-Filter, Authorization, X-Filter
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1557762087'
+      Retry-After:
+      - '118'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"type": "g6-standard-1", "updated": "2019-05-13T15:34:03", "alerts":
+        {"cpu": 90, "network_out": 10, "io": 10000, "network_in": 10, "transfer_quota":
+        80}, "ipv6": "2600:3c00::f03c:91ff:fec3:ff5d/64", "status": "running", "watchdog_enabled":
+        true, "group": "", "created": "2019-05-13T15:34:03", "specs": {"memory": 2048,
+        "disk": 51200, "vcpus": 1, "transfer": 2000}, "region": "us-central", "ipv4":
+        ["198.58.120.51"], "image": "linode/centos7", "backups": {"enabled": false,
+        "schedule": {"day": null, "window": null}}, "id": 13985782, "label": "centos-us-central",
+        "hypervisor": "kvm", "tags": []}'
+    http_version: 
+  recorded_at: Mon, 13 May 2019 15:39:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fog/linode/compute/requests/delete_server_spec.rb
+++ b/spec/fog/linode/compute/requests/delete_server_spec.rb
@@ -1,0 +1,25 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#delete_server' do
+    before do
+      VCR.insert_cassette('delete_server')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'deletes the specified Linode instace' do
+      server_response = connection.delete_server(13985782)
+      assert_empty server_response
+    end
+  end
+end

--- a/spec/fog/linode/compute/requests/list_servers_spec.rb
+++ b/spec/fog/linode/compute/requests/list_servers_spec.rb
@@ -1,0 +1,26 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#list_servers' do
+    before do
+      VCR.insert_cassette('list_servers')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'lists existing Linode images' do
+      images_response = connection.list_servers
+      assert !images_response.empty?
+      assert !images_response.first['id'].nil?
+    end
+  end
+end

--- a/spec/fog/linode/compute/requests/view_server_spec.rb
+++ b/spec/fog/linode/compute/requests/view_server_spec.rb
@@ -1,0 +1,26 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#view_server' do
+    before do
+      VCR.insert_cassette('view_server')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'loads the specified image' do
+      image_response = connection.view_server(13985782)
+      assert_equal image_response['id'], 13985782
+      assert_equal image_response['label'], 'centos-us-central'
+    end
+  end
+end


### PR DESCRIPTION
Read and delete actions for Linode instances are straightforward
since we don't need to concern ourselves with data structures or
validation rules.  All we need is an API token and (for viewing
and deleting) an instance ID.