### PR TITLE
Add models for Linode instances (a.k.a. servers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ finnix = compute.kernels.get('linode/finnix-legacy') # Load details for a single
 # Complex filtering
 wordpress_stack_scripts = compute.stack_scripts.all(filters: { description: { '+contains': 'WordPress' } }) # Load all StackScripts with a description containing 'WordPress'
 
+# Creating a Linode instance
+regions = compute.regions.all
+types = compute.types.all
+images = compute.images.all({filters: { label: { '+contains': 'CentOS' } } })
+server = compute.servers.new
+server.region = regions[2].id
+server.type = types[4].id
+server.image = images.first.id
+server.root_pass = '<password>'
+server.save
+
+# Updating a Linode instance
+server.tags = ['add', 'some', 'tags']
+server.save
+
+# Working with Linode Domains
 dns = Fog::DNS.new(provider: :linode, linode_token: '<your LinodeAPIv4 access token>')
 all_domains = dns.domains.all # Load all Linode Domains on your account
 exsiting_domain = dns.domains.get(1234567890) # Load details for a single Linode Domain on your account

--- a/lib/fog/linode/compute.rb
+++ b/lib/fog/linode/compute.rb
@@ -28,6 +28,8 @@ module Fog
       model :kernel
       collection :regions
       model :region
+      collection :servers
+      model :server
       collection :stack_scripts
       model :stack_script
       collection :images

--- a/lib/fog/linode/compute/models/server.rb
+++ b/lib/fog/linode/compute/models/server.rb
@@ -1,0 +1,56 @@
+require 'fog/core/model'
+
+module Fog
+  module Linode
+    class Compute
+      # Read-only model for Linode instances
+      class Server < Fog::Model
+        identity :id
+
+        attribute :label
+        attribute :region
+        attribute :image
+        attribute :type
+        attribute :group
+        attribute :tags
+        attribute :status
+        attribute :hypervisor
+        attribute :created
+        attribute :updated
+        attribute :ipv4
+        attribute :ipv6
+        attribute :specs
+        attribute :alerts
+        attribute :backups
+        attribute :watchdog_enabled
+
+        # Attributes for creation (not available when viewing, not supported for update)
+        attribute :backup_id
+        attribute :backups_enabled
+        attribute :swap_size
+        attribute :root_pass
+        attribute :authorized_keys
+        attribute :stackscript_id
+        attribute :stackscript_data
+        attribute :booted
+        attribute :private_ip
+        attribute :authorized_users
+
+        def save
+          if identity.nil?
+            merge_attributes(service.create_server(attributes))
+          else
+            merge_attributes(service.update_server(identity, attributes_for_update))
+          end
+        end
+
+        private
+
+        def attributes_for_update
+          supported_attributes = %i[label group tags alerts backups watchdog_enabled]
+          attributes.dup.select { |key| supported_attributes.include? key }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/models/servers.rb
+++ b/lib/fog/linode/compute/models/servers.rb
@@ -1,0 +1,23 @@
+require 'fog/core/collection'
+require 'fog/linode/compute/models/kernel'
+
+module Fog
+  module Linode
+    class Compute
+      # Collection class for loading Server models from Linode instance data
+      class Servers < Fog::Collection
+        model Server
+
+        def all(options = {})
+          servers = service.list_servers(options)
+          load servers
+        end
+
+        def get(id)
+          server = service.view_server(id)
+          new server
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for creating and updating Linode instances via
the fog ORM layer.  Sample code is added to the README to provide
an example of using the ORM layer to create a Linode instance.